### PR TITLE
Onboard npm pipelines to CFS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@opentelemetry:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -48,6 +48,10 @@ extends:
                           displayName: 'Install Node.js'
                           inputs:
                               versionSpec: 18.x
+                        - task: npmAuthenticate@0
+                          displayName: 'Authenticate to CFS npm feed'
+                          inputs:
+                              workingFile: '$(Build.SourcesDirectory)/.npmrc'
                         - script: npm ci
                           displayName: 'npm ci'
                         - script: 'npm run validateRelease -- --publishTag ${{ parameters.NpmPublishTag }} --dropPath "$(Pipeline.Workspace)/officialBuild/drop"'

--- a/azure-pipelines/templates/build.yml
+++ b/azure-pipelines/templates/build.yml
@@ -14,6 +14,10 @@ jobs:
             inputs:
                 versionSpec: 20.x
             displayName: 'Install Node.js'
+          - task: npmAuthenticate@0
+            displayName: 'Authenticate to CFS npm feed'
+            inputs:
+                workingFile: '$(Build.SourcesDirectory)/.npmrc'
           - script: npm ci
             displayName: 'npm ci'
           - script: npm run updateVersion -- --buildNumber $(Build.BuildNumber)

--- a/azure-pipelines/templates/test.yml
+++ b/azure-pipelines/templates/test.yml
@@ -15,6 +15,10 @@ jobs:
             inputs:
                 versionSpec: $(NODE_VERSION)
             displayName: 'Install Node.js'
+          - task: npmAuthenticate@0
+            displayName: 'Authenticate to CFS npm feed'
+            inputs:
+                workingFile: '$(Build.SourcesDirectory)/.npmrc'
           - script: npm ci
             displayName: 'npm ci'
           - script: npm run build


### PR DESCRIPTION
## Summary
- route npm dependency resolution through `azfunc/public/upstream-public`
- map the complete resolved production scopes (`@opentelemetry` and `@types`) to CFS
- authenticate CFS before npm execution in test, build/package, and release jobs

## Audit
- one npm project; no npm workspaces, global installs, sudo npm, or pipeline npx paths
- no NuGet or Python package projects, so no ecosystem-specific changes apply
- package-lock URLs and npm registry replacement defaults remain unchanged
- customer-facing examples/templates and package runtime behavior are untouched
- detached packaging does not restore dependencies; release publishing retains its existing service connection

## Validation
- authenticated cold-cache `npm ci` completed with 592 CFS/Azure Artifacts fetches and 0 direct `registry.npmjs.org` fetches
- resolved installed production graph contains only the configured `@opentelemetry` and `@types` scopes
- build, lint, version validation, and 18 tests completed successfully
- minified build and detached-tree release validation completed from a path containing spaces
- `npm pack --dry-run`, actual pack inspection, and `npm publish --dry-run` found 14 package files and no `.npmrc`, credentials, or internal configuration