### PR TITLE
CodeQL Support

### DIFF
--- a/azure-pipelines/official-build.yml
+++ b/azure-pipelines/official-build.yml
@@ -35,6 +35,10 @@ extends:
             image: 1es-windows-2022
             os: windows
 
+        sdl:
+            codeql:
+                runSourceLanguagesInSourceAnalysis: true
+
         stages:
             - stage: WindowsUnitTests
               dependsOn: []


### PR DESCRIPTION
# [SFI-PS2.1] Onboard repo to CodeQL

## Summary

Onboards the `azure-functions-nodejs-opentelemetry` repository to CodeQL by enabling
CodeQL source-language analysis in the **official (internal) build** pipeline. This
closes the SFI-PS2.1 CodeQL onboarding gap for this repo.

Resolves [Azure/azure-functions-bucees-planning#1195](https://github.com/Azure/azure-functions-bucees-planning/issues/1195).

## Background

CodeQL was already enabled in two of the three 1ES pipelines:

| Pipeline | CodeQL before | CodeQL after |
| --- | --- | --- |
| `azure-pipelines/public-build.yml` | ✅ Enabled | ✅ Enabled (unchanged) |
| `azure-pipelines/release.yml` | ✅ Enabled | ✅ Enabled (unchanged) |
| `azure-pipelines/official-build.yml` | ❌ Missing | ✅ Enabled |

The **official build** is the internal pipeline where SDL/security analysis results are
reported for SFI compliance, so CodeQL must run there. It was the only pipeline missing
the `sdl.codeql` configuration.

## Changes

Added the CodeQL SDL block to `azure-pipelines/official-build.yml`, matching the
configuration used by the sibling repository
[`azure-functions-nodejs-library`](https://github.com/Azure/azure-functions-nodejs-library/tree/v4.x/azure-pipelines):

```yaml
extends:
    template: v1/1ES.Official.PipelineTemplate.yml@1es
    parameters:
        pool:
            name: 1es-pool-azfunc
            image: 1es-windows-2022
            os: windows

        sdl:
            codeql:
                runSourceLanguagesInSourceAnalysis: true

        stages:
            ...
```

`runSourceLanguagesInSourceAnalysis: true` enables CodeQL analysis of the repo's
source languages (JavaScript/TypeScript) during the 1ES source-analysis stage.

## Scope

- Change is limited strictly to CodeQL onboarding.
- No unrelated SDL tools (e.g. `npm audit` vulnerability scanning) were added.
- No source code, build, or test changes.

## Validation

- YAML validated — no syntax errors.

